### PR TITLE
feat: update terraform provider version constraint to support 5.x

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = "=> 4.0, < 6.0"
     }
   }
 }

--- a/versions.tm.hcl
+++ b/versions.tm.hcl
@@ -4,7 +4,7 @@ globals {
   provider                    = "google"
   minimum_provider_version    = "4.0"
 
-  provider_version_constraint  = "~> ${global.minimum_provider_version}"
+  provider_version_constraint  = ">= 4, < 6"
   terraform_version_constraint = "~> ${global.minimum_terraform_version}, != 1.1.0, != 1.1.1"
   # we exclude 1.1.0 and 1.1.1 because of:
   # https://github.com/hashicorp/terraform/blob/v1.1/CHANGELOG.md#112-december-17-2021


### PR DESCRIPTION
we want to start using a newer version of the google provider