### PR TITLE
feat: add support for pricipal and principalSet in IAM members

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -39,8 +39,8 @@ jobs:
           GOPROXY: direct
 
       - name: Cache plugin dir
-        # actions/cache@v4.0.0 -> 13aacd865c20de90d75de3b17ebe84f7a17d57d2
-        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
+        # actions/cache@v4.2.3 -> 5a3ec84eff668545956fd18022155c47e93e2684
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
         with:
           path: ~/.tflint.d/plugins
           key: tflint-${{ hashFiles('.tflint.hcl') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,8 @@ jobs:
           GOPROXY: direct
 
       - name: Cache plugin dir
-        # actions/cache@v4.0.0 -> 13aacd865c20de90d75de3b17ebe84f7a17d57d2
-        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
+        # actions/cache@v4.2.3 -> 5a3ec84eff668545956fd18022155c47e93e2684
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
         with:
           path: ~/.tflint.d/plugins
           key: tflint-${{ hashFiles('.tflint.hcl') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0]
+
+### Added
+
+- Add support for `principal` and `principalSet` in IAM members
+
+## [0.2.0]
+
+### Added
+
+- Add support for google v5 provider
+
 ## [0.1.0]
 
 ### Added
@@ -44,7 +56,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- markdown-link-check-disable -->
 
-[unreleased]: https://github.com/mineiros-io/terraform-google-secret-manager-iam/compare/v0.1.0...HEAD
+[unreleased]: https://github.com/mineiros-io/terraform-google-secret-manager-iam/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/mineiros-io/terraform-google-secret-manager-iam/compare/v0.2.4...v0.3.0
+[0.2.0]: https://github.com/mineiros-io/terraform-google-secret-manager-iam/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/mineiros-io/terraform-google-secret-manager-iam/compare/v0.0.4...v0.1.0
 [0.0.4]: https://github.com/mineiros-io/terraform-google-secret-manager-iam/compare/v0.0.3...v0.0.4
 [0.0.3]: https://github.com/mineiros-io/terraform-google-secret-manager-iam/compare/v0.0.2...v0.0.3

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Most basic usage just setting required arguments:
 
 ```hcl
 module "terraform-google-secret-manager-iam" {
-  source = "github.com/mineiros-io/terraform-google-secret-manager-iam.git?ref=v0.1.0"
+  source = "github.com/mineiros-io/terraform-google-secret-manager-iam.git?ref=v0.3.0"
 
   secret_id = google_secret_manager_secret.secret-basic.secret_id
   role      = "roles/secretmanager.secretAccessor"
@@ -82,6 +82,8 @@ See [variables.tf] and [examples/] for details and use-cases.
   - `projectEditor:projectid`: Editors of the given project. For example, `projectEditor:my-example-project`
   - `projectViewer:projectid`: Viewers of the given project. For example, `projectViewer:my-example-project`
   - `computed:{identifier}`: An existing key from var.computed_members_map.
+  - `principal://{identifier}`: Principal identifier as documented by Google Cloud. For example `principal://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/subject/SUBJECT_ATTRIBUTE_VALUE`
+  - `principalSet://{identifier}`: Principal set identifier as documented by Google Cloud. For example `principalSet://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/*`
 
   Default is `[]`.
 

--- a/README.tfdoc.hcl
+++ b/README.tfdoc.hcl
@@ -56,7 +56,7 @@ section {
 
       ```hcl
       module "terraform-google-secret-manager-iam" {
-        source = "github.com/mineiros-io/terraform-google-secret-manager-iam.git?ref=v0.1.0"
+        source = "github.com/mineiros-io/terraform-google-secret-manager-iam.git?ref=v0.3.0"
 
         secret_id = google_secret_manager_secret.secret-basic.secret_id
         role      = "roles/secretmanager.secretAccessor"
@@ -97,6 +97,8 @@ section {
             - `projectEditor:projectid`: Editors of the given project. For example, `projectEditor:my-example-project`
             - `projectViewer:projectid`: Viewers of the given project. For example, `projectViewer:my-example-project`
             - `computed:{identifier}`: An existing key from var.computed_members_map.
+            - `principal://{identifier}`: Principal identifier as documented by Google Cloud. For example `principal://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/subject/SUBJECT_ATTRIBUTE_VALUE`
+            - `principalSet://{identifier}`: Principal set identifier as documented by Google Cloud. For example `principalSet://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/*`
             END
         }
 

--- a/test/unit-complete/main.tf
+++ b/test/unit-complete/main.tf
@@ -108,3 +108,18 @@ module "test4" {
 
   # add most/all other optional arguments
 }
+
+# principal and principalSet test
+module "test5" {
+  source = "../.."
+
+  secret_id = "unit-complete"
+
+  role = "roles/viewer"
+
+  authoritative = false
+  members = [
+    "principalSet://iam.googleapis.com/locations/global/workforcePools/test_pool/*",
+    "principal://iam.googleapis.com/locations/global/workforcePools/test_pool/subject/test_attribute",
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -15,12 +15,12 @@ variable "secret_id" {
 
 variable "members" {
   type        = set(string)
-  description = "(Optional) Identities that will be granted the privilege in role. Each entry can have one of the following values: 'allUsers', 'allAuthenticatedUsers', 'user:{emailid}', 'serviceAccount:{emailid}', 'group:{emailid}', 'domain:{domain}', 'projectOwner:projectid', 'projectEditor:projectid', 'projectViewer:projectid'."
+  description = "(Optional) Identities that will be granted the privilege in role. Each entry can have one of the following values: 'allUsers', 'allAuthenticatedUsers', 'user:{emailid}', 'serviceAccount:{emailid}', 'group:{emailid}', 'domain:{domain}', 'projectOwner:projectid', 'projectEditor:projectid', 'projectViewer:projectid', 'principalSet:{principalSet}', 'principal:{principal}'."
   default     = []
 
   validation {
-    condition     = alltrue([for m in var.members : can(regex("^(allUsers|allAuthenticatedUsers|(user|serviceAccount|group|domain|projectOwner|projectEditor|projectViewer|computed):)", m))])
-    error_message = "The value must be a non-empty list of strings where each entry is a valid principal type identified with `user:`, `serviceAccount:`, `group:`, `domain:`, `projectOwner:`, `projectEditor:`, `projectViewer:` or `computed`."
+    condition     = alltrue([for m in var.members : can(regex("^(allUsers|allAuthenticatedUsers|(user|serviceAccount|group|domain|projectOwner|projectEditor|projectViewer|computed|principalSet|principal):)", m))])
+    error_message = "The value must be a non-empty list of strings where each entry is a valid principal type identified with `user:`, `serviceAccount:`, `group:`, `domain:`, `projectOwner:`, `projectEditor:`, `projectViewer:`, `principalSet:`, `principal:` or `computed`."
   }
 }
 
@@ -30,8 +30,8 @@ variable "computed_members_map" {
   default     = {}
 
   validation {
-    condition     = alltrue([for k, v in var.computed_members_map : can(regex("^(allUsers|allAuthenticatedUsers|(user|serviceAccount|group|domain|projectOwner|projectEditor|projectViewer):)", v))])
-    error_message = "The value must be a non-empty list of strings where each entry is a valid principal type identified with `user:`, `serviceAccount:`, `group:`, `domain:`, `projectOwner:`, `projectEditor:` or `projectViewer:`."
+    condition     = alltrue([for k, v in var.computed_members_map : can(regex("^(allUsers|allAuthenticatedUsers|(user|serviceAccount|group|domain|projectOwner|projectEditor|projectViewer|principalSet|principal):)", v))])
+    error_message = "The value must be a non-empty list of strings where each entry is a valid principal type identified with `user:`, `serviceAccount:`, `group:`, `domain:`, `projectOwner:`, `projectEditor:`, `projectViewer:`, `principalSet:` or `principal:`."
   }
 }
 


### PR DESCRIPTION
Originally created by @Silthus in https://github.com/mineiros-io/terraform-google-secret-manager-iam/pull/22

This PR fixes the IAM module to allow a principal:// or principalSet:// to be passed to the members.

Principals and PrincipalSets can be used for granting access to Workload Identities or other [Principal Identifiers](https://cloud.google.com/iam/docs/principal-identifiers)